### PR TITLE
Issues with label@for/input@id and previous assigned events

### DIFF
--- a/will_pickdate.js
+++ b/will_pickdate.js
@@ -78,13 +78,13 @@
     this.clone = this.element
             .css('display', this.options.debug ? this.display : 'none')
             .data('will_pickdate', true)
-            .clone()
+            .clone(true)
             .data('will_pickdate', true)
             .removeAttr('name')
             .css('display', this.display)
             .val(init_clone_val);
 
-    this.element.after(this.clone);
+    this.element.before(this.clone);
 
     if(this.toggler) {
       this.toggler.css('cursor', 'pointer').click($.proxy(function(event) {


### PR DESCRIPTION
Keep element assigned events with the clone, and put the clone BEFORE the element to keep the label@for/input@id relationship.
