### PR TITLE
Fixing when you set 12:xx XM hours

### DIFF
--- a/src/will_pickdate.js
+++ b/src/will_pickdate.js
@@ -487,10 +487,17 @@
 
       container.append($('<input type="submit" value="OK" class="ok"/>').click($.proxy(function(event) {
         event.stopPropagation();
+        
+        var parsedHours = parseInt(this.picker.find('.hour').val(), 10);
+        if(!this.options.militaryTime){
+      	    parsedHours = parsedHours === 12 ? 0 : parsedHours;
+      	}
+        
         this.select($.extend(this.dateToObject(this.working_date),
-          { hours: parseInt(this.picker.find('.hour').val(), 10) +
-              (!this.options.militaryTime && this.picker.find('.ampm').val() == "PM" ? 12 : 0),
-            minutes: parseInt(this.picker.find('.minutes').val(), 10) }));
+          {
+      	    hours: parsedHours + (!this.options.militaryTime && this.picker.find('.ampm').val() == "PM" ? 12 : 0),
+      	    minutes: parseInt(this.picker.find('.minutes').val(), 10)
+      	  }));
       }, this)));
     },
 


### PR DESCRIPTION
## Bug
- When you try to set 12:xx AM to the picker it will set 12:xx PM because it sums 12 hours.
- For 12:xx PM it sets 12:xx AM for the next day because it sums 24 hours.
## Solution

  If the hours are set to 12 in the no military time, it will set to 0.
